### PR TITLE
Remove changelog check from PR template & codecov version update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             . .venv/bin/activate
             pip install --upgrade pip
             make test_requirements
-            make test
+            make test -- --codecov-token=${CODECOV_TOKEN}
   publish_to_pypi:
     docker:
       - image: cimg/python:3.9

--- a/makefile
+++ b/makefile
@@ -11,15 +11,18 @@ flake8:
 	flake8 . --exclude=.venv --max-line-length=120
 
 pytest:
-	pytest . --cov=. $(pytest_args) --capture=no --last-failed -vv
+	pytest . $(pytest_args) --capture=no --last-failed -vv
 
-CODECOV := \
-	if [ "$$CODECOV_REPO_TOKEN" != "" ]; then \
-	   codecov --token=$$CODECOV_REPO_TOKEN ;\
-	fi
+pytest_codecov:
+	pytest \
+		--junitxml=test-reports/junit.xml \
+		--cov-config=.coveragerc \
+		--cov-report=term \
+		--cov=. \
+		--codecov \
+		$(ARGUMENTS)
 
-test: flake8 pytest
-	$(CODECOV)
+test: flake8 pytest_codecov
 
 publish:
 	rm -rf build dist; \

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 To do (delete all that do not apply):
  - [ ] Change has a jira ticket that has the correct status.
- - [ ] Changelog entry added.
+ - [ ] A clear description/pull request message has been added.
  - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
  - [ ] (if updating requirements) Requirements have been compiled.
  - [ ] (if adding env vars) Added any new environment variable to vault.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_forms_api_client',
-    version='7.1.0',
+    version='7.1.1',
     url='https://github.com/uktrade/directory-forms-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -19,10 +19,11 @@ setup(
     ],
     extras_require={
         'test': [
-            'codecov==2.1.9',
             'django>=2.2.10,<4.0.0',
             'flake8==3.8.3',
-            'pytest-cov==2.10.1',
+            "pytest-codecov",
+            "pytest-cov",
+            "GitPython",
             'pytest-django==3.10.0',
             'pytest==6.1.0',
             'requests>=2.22.0,<3.0.0',


### PR DESCRIPTION
This PR updates the PR template to no longer mention the changelog as we are no longer mantaining it.

To be able to unblock the CI pipeline, this PR also includes an update to our codecov configuration to use pytest-codecov rather than the outdated codecov

 - [x] Change has a jira ticket that has the correct status.