### PR TITLE
use latest version of directory-client-core and bump django to 4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## [7.2.0](https://pypi.org/project/directory-forms-api-client/7.2.1/) (2023-07-05)
-[Full Changelog](
+## [7.2.1](https://pypi.org/project/directory-forms-api-client/7.2.1/) (2023-07-05)
+[Full Changelog](https://github.com/uktrade/directory-forms-api-client/pull/42)
 - KLS-822 - Update Django to 4.2.3 and use at lease 7.2.4 of directory-client-core
 
 ## [7.2.0](https://pypi.org/project/directory-forms-api-client/7.2.0/) (2022-05-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [7.2.0](https://pypi.org/project/directory-forms-api-client/7.2.1/) (2023-07-05)
+[Full Changelog](
+- KLS-822 - Update Django to 4.2.3 and use at lease 7.2.4 of directory-client-core
+
 ## [7.2.0](https://pypi.org/project/directory-forms-api-client/7.2.0/) (2022-05-23)
 [Full Changelog](https://github.com/uktrade/directory-forms-api-client/pull/41)
 - KLS-622 - Update Django to 4.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_forms_api_client',
-    version='7.2.0',
+    version='7.2.1',
     url='https://github.com/uktrade/directory-forms-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -15,11 +15,11 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'directory_client_core>=6.1.0,<8.0.0',
+        'directory_client_core>=7.2.4,<8.0.0',
     ],
     extras_require={
         'test': [
-            'django>=2.2.10,<=4.2',
+            'django>=2.2.10,<=4.2.3',
             'flake8==3.8.3',
             "pytest-codecov",
             "pytest-cov",


### PR DESCRIPTION
use latest version of directory-client-core and bump django to 4.2.3

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.

