### PR TITLE
DPE-529 - Parameterise sorting of fields in zendesk ticket

### DIFF
--- a/directory_forms_api_client/actions.py
+++ b/directory_forms_api_client/actions.py
@@ -74,7 +74,7 @@ class ZendeskAction(AbstractAction):
     name = 'zendesk'
 
     def __init__(
-        self, subject, full_name, email_address, service_name, subdomain=None,
+        self, subject, full_name, email_address, service_name, subdomain=None, sort_fields_alphabetically=True,
         *args, **kwargs
     ):
         self.meta = {
@@ -82,6 +82,7 @@ class ZendeskAction(AbstractAction):
             'email_address': email_address,
             'subject': subject,
             'service_name': service_name,
+            'sort_fields_alphabetically': sort_fields_alphabetically
         }
         # if empty Forms API will use the default configured zendesk subdomain
         if subdomain:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_forms_api_client',
-    version='7.2.2',
+    version='7.3.0',
     url='https://github.com/uktrade/directory-forms-api-client',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -133,7 +133,8 @@ def test_zendesk_action_mixin_action_class(
             },
             'spam_control': {
                 'contents': ['hello buy my goods'],
-            }
+            },
+            'sort_fields_alphabetically': True,
         }
     })
 
@@ -177,7 +178,8 @@ def test_zendesk_action_mixin_action_class_subdomain(
             },
             'spam_control': {
                 'contents': ['hello buy my goods'],
-            }
+            },
+            'sort_fields_alphabetically': True,
         }
     })
 


### PR DESCRIPTION
This PR enables the client to be instantiated with a parameter indicating whether or not the enquiry fields in a Zendesk action should be sorted alphabetically. Refer to corresponding directory-forms-api [PR](https://github.com/uktrade/directory-forms-api/pull/246) for further details.

To do (delete all that do not apply):
 - [x] Change has a jira ticket that has the correct status. - [Jira](https://uktrade.atlassian.net/jira/software/projects/DPE/boards/397/backlog?selectedIssue=DPE-529)
 - [x] A clear description/pull request message has been added.

