### PR TITLE
DPE-529 - bump version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_forms_api_client',
-    version='7.3.0',
+    version='7.3.1',
     url='https://github.com/uktrade/directory-forms-api-client',
     license='MIT',
     author='Department for International Trade',


### PR DESCRIPTION
Small amendment on [this pr](https://github.com/uktrade/directory-forms-api-client/pull/44) - bump version number to enable uploading to PyPi.