### PR TITLE
Upgrade/kls 1948 bump django 4.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## [7.2.3]() (2024-02-20)
-[Full Changelog]()
+## [7.2.3](https://pypi.org/project/directory-forms-api-client/7.2.3/) (2024-02-20)
+[Full Changelog](https://github.com/uktrade/directory-forms-api-client/pull/46)
 - KLS-1948 - Bump Django to 4.2.10 minimum
 
 ## [7.2.2](https://pypi.org/project/directory-forms-api-client/7.2.2/) (2023-07-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [7.2.3]() (2024-02-20)
+[Full Changelog]()
+- KLS-1948 - Bump Django to 4.2.10 minimum
+
 ## [7.2.2](https://pypi.org/project/directory-forms-api-client/7.2.2/) (2023-07-06)
 [Full Changelog](https://github.com/uktrade/directory-forms-api-client/pull/43)
 - KLS-822 - use at lease 7.2.5 of directory-client-core

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'directory_client_core>=7.2.8,<8.0.0',
+        'directory_client_core>=7.2.12,<8.0.0',
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_forms_api_client',
-    version='7.3.2',
+    version='7.3.3',
     url='https://github.com/uktrade/directory-forms-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -19,7 +19,7 @@ setup(
     ],
     extras_require={
         'test': [
-            'django>=2.2.10,<=4.2.3',
+            'django>=4.2.10,<5.0',
             'flake8==3.8.3',
             "pytest-codecov",
             "pytest-cov",


### PR DESCRIPTION
To do (delete all that do not apply):
 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.

