### PR TITLE
Add V2 API gov.notify bulk email sending

### DIFF
--- a/directory_forms_api_client/actions.py
+++ b/directory_forms_api_client/actions.py
@@ -106,6 +106,22 @@ class GovNotifyEmailAction(AbstractAction):
         super().__init__(*args, **kwargs)
 
 
+class GovNotifyBulkEmailAction(AbstractAction):
+    name = 'gov-notify-bulk-email'
+
+    def __init__(
+        self, template_id, email_addresses, email_reply_to_id=None,
+        *args, **kwargs
+    ):
+        self.meta = {
+            'template_id': template_id,
+            'email_addresses': email_addresses,
+        }
+        if email_reply_to_id:
+            self.meta['email_reply_to_id'] = email_reply_to_id
+        super().__init__(*args, **kwargs)
+
+
 class GovNotifyLetterAction(AbstractAction):
     name = 'gov-notify-letter'
 

--- a/directory_forms_api_client/client.py
+++ b/directory_forms_api_client/client.py
@@ -8,12 +8,16 @@ from directory_client_core.base import AbstractAPIClient
 class APIFormsClient(AbstractAPIClient):
 
     endpoints = {
+        # API V1 endpoints
         'ping': 'api/healthcheck/ping/',
         'submission': 'api/submission/',
-        'delete_submissions': 'api/delete-submissions/'
+        'delete_submissions': 'api/delete-submissions/',
+        # API V2 endpoints
+        'gov_notify_bulk_email': 'api/v2/gov-notify-bulk-email/'
     }
     version = pkg_resources.get_distribution(__package__).version
 
+    # API V1
     def ping(self, authenticator=None):
         return self.get(url=self.endpoints['ping'], authenticator=authenticator)
 
@@ -23,6 +27,18 @@ class APIFormsClient(AbstractAPIClient):
     def delete_submissions(self, email_address, authenticator=None):
         endpoint = self.endpoints['delete_submissions'] + f'{email_address}/'
         return self.delete(url=endpoint, authenticator=authenticator)
+
+    # API V2
+    def gov_notify_bulk_email(self, data, authenticator=None):
+        """
+        Allows an email with multiple recipients to be sent be gov.notify.
+
+        :param data: Email meta data.
+        :param authenticator: API authenticator class (default None)
+        :return: Request object
+        """
+
+        return self.post(url=self.endpoints['gov_notify_bulk_email'], data=data, authenticator=authenticator)
 
 
 forms_api_client = APIFormsClient(

--- a/directory_forms_api_client/forms.py
+++ b/directory_forms_api_client/forms.py
@@ -49,6 +49,10 @@ class GovNotifyEmailActionMixin(AbstractActionMixin):
     action_class = actions.GovNotifyEmailAction
 
 
+class GovNotifyBulkEmailActionMixin(AbstractActionMixin):
+    action_class = actions.GovNotifyBulkEmailAction
+
+
 class GovNotifyLetterActionMixin(AbstractActionMixin):
     action_class = actions.GovNotifyLetterAction
 
@@ -70,6 +74,10 @@ class ZendeskAPIForm(ZendeskActionMixin, Form):
 
 
 class GovNotifyEmailAPIForm(GovNotifyEmailActionMixin, Form):
+    pass
+
+
+class GovNotifyBulkEmailAPIForm(GovNotifyBulkEmailActionMixin, Form):
     pass
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_forms_api_client',
-    version='7.3.4',
+    version='7.4.4',
     url='https://github.com/uktrade/directory-forms-api-client',
     license='MIT',
     author='Department for International Trade',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_forms_api_client',
-    version='7.4.4',
+    version='7.4.0',
     url='https://github.com/uktrade/directory-forms-api-client',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -261,6 +261,83 @@ def test_gov_notify_email_action_mixin_action_class_no_reply_id(
     })
 
 
+def test_gov_notify_bulk_email_action_mixin_action_class(
+        settings, form_session, spam_control, sender
+):
+    mock_client = mock.Mock(spec_set=client.APIFormsClient)
+    action = actions.GovNotifyBulkEmailAction(
+        client=mock_client,
+        template_id='123456',
+        email_addresses=['one@example.com', 'two@example.com', 'three@example.com'],
+        email_reply_to_id='123',
+        form_url='/the/form/',
+        form_session=form_session,
+        spam_control=spam_control,
+        sender=sender,
+    )
+
+    action.save({'name': 'hello'})
+    assert mock_client.submit_generic.call_count == 1
+    assert mock_client.submit_generic.call_args == mock.call({
+        'data': {'name': 'hello'},
+        'meta': {
+            'action_name': 'gov-notify-bulk-email',
+            'template_id': '123456',
+            'email_addresses': ['one@example.com', 'two@example.com', 'three@example.com'],
+            'email_reply_to_id': '123',
+            'form_url': '/the/form/',
+            'funnel_steps': ['one', 'two'],
+            'ingress_url': 'example.com',
+            'sender': {
+                'email_address': 'foo@example.com',
+                'country_code': 'UK',
+                'ip_address': '192.168.0.1',
+            },
+            'spam_control': {
+                'contents': ['hello buy my goods'],
+            }
+        }
+    })
+
+
+def test_gov_notify_bulk_email_action_mixin_action_class_no_reply_id(
+        settings, form_session, spam_control, sender
+):
+    mock_client = mock.Mock(spec_set=client.APIFormsClient)
+    action = actions.GovNotifyBulkEmailAction(
+        client=mock_client,
+        template_id='123456',
+        email_addresses=['one@example.com', 'two@example.com', 'three@example.com'],
+        form_url='/the/form/',
+        form_session=form_session,
+        spam_control=spam_control,
+        sender=sender,
+    )
+
+    action.save({'name': 'hello'})
+
+    assert mock_client.submit_generic.call_count == 1
+    assert mock_client.submit_generic.call_args == mock.call({
+        'data': {'name': 'hello'},
+        'meta': {
+            'action_name': 'gov-notify-bulk-email',
+            'template_id': '123456',
+            'email_addresses': ['one@example.com', 'two@example.com', 'three@example.com'],
+            'form_url': '/the/form/',
+            'funnel_steps': ['one', 'two'],
+            'ingress_url': 'example.com',
+            'sender': {
+                'email_address': 'foo@example.com',
+                'country_code': 'UK',
+                'ip_address': '192.168.0.1',
+            },
+            'spam_control': {
+                'contents': ['hello buy my goods'],
+            }
+        }
+    })
+
+
 def test_pardot_action_mixin_action_class(
         settings, form_session, spam_control, sender
 ):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -63,3 +63,20 @@ class APIFormsClientTest(TestCase):
         assert APIFormsClient.version == pkg_resources.get_distribution(
             'directory-forms-api-client'
         ).version
+
+    # API V2
+    @stub_request('https://forms.com/api/v2/gov-notify-bulk-email/', 'post')
+    def test_gov_notify_bulk_email_generic(self, stub):
+        data = {'field_one': 'value_one'}
+        self.client.gov_notify_bulk_email(data)
+
+        request = stub.request_history[0]
+        assert request.json() == data
+
+    @stub_request('https://forms.com/api/v2/gov-notify-bulk-email/', 'post')
+    def test_gov_notify_bulk_email_with_authenticator(self, stub):
+        data = {'field_one': 'value_one'}
+        self.client.gov_notify_bulk_email(data)
+
+        request = stub.request_history[0]
+        assert request.json() == data

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -306,6 +306,52 @@ def test_gov_notify_action_no_reply_to_id(
 
 
 @pytest.mark.parametrize('classes', (
+    [forms.GovNotifyBulkEmailActionMixin, Form],
+    [forms.GovNotifyBulkEmailAPIForm]
+))
+def test_gov_notify_bulk_email_action(
+    classes, mock_action_class, form_session, spam_control, sender,
+):
+
+    class TestForm(*classes):
+        action_class = mock_action_class
+
+        title = fields.CharField()
+
+    data = {
+        'email_addresses': ['one@example.com', 'two@example.com', 'three@example.com'],
+        'template_id': '123456',
+        'title': 'some title',
+    }
+
+    form = TestForm(data)
+    assert form.is_valid()
+
+    form.save(
+        template_id=data['template_id'],
+        email_addresses=data['email_addresses'],
+        email_reply_to_id='123',
+        form_url='/the/form/',
+        form_session=form_session,
+        spam_control=spam_control,
+        sender=sender,
+    )
+
+    assert mock_action_class.call_count == 1
+    assert mock_action_class.call_args == mock.call(
+        template_id=data['template_id'],
+        email_addresses=data['email_addresses'],
+        email_reply_to_id='123',
+        form_url='/the/form/',
+        form_session=form_session,
+        spam_control=spam_control,
+        sender=sender,
+    )
+    assert mock_action_class().save.call_count == 1
+    assert mock_action_class().save.call_args == mock.call(form.cleaned_data)
+
+
+@pytest.mark.parametrize('classes', (
     [forms.PardotActionMixin, Form],
     [forms.PardotAPIForm]
 ))


### PR DESCRIPTION
This ticket adds supports for the new V2 API Bulk Email sending functionality to gov.notify. 


Related ticket: https://uktrade.atlassian.net/jira/software/c/projects/GREATUK/boards/484?selectedIssue=GREATUK-90