### PR TITLE
Add bulk sending to directory forms api client

### DIFF
--- a/directory_forms_api_client/actions.py
+++ b/directory_forms_api_client/actions.py
@@ -110,12 +110,11 @@ class GovNotifyBulkEmailAction(AbstractAction):
     name = 'gov-notify-bulk-email'
 
     def __init__(
-        self, template_id, email_addresses, email_reply_to_id=None,
+        self, template_id, email_reply_to_id=None,
         *args, **kwargs
     ):
         self.meta = {
-            'template_id': template_id,
-            'email_addresses': email_addresses,
+            'template_id': template_id
         }
         if email_reply_to_id:
             self.meta['email_reply_to_id'] = email_reply_to_id

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_forms_api_client',
-    version='7.4.0',
+    version='7.4.1',
     url='https://github.com/uktrade/directory-forms-api-client',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -276,16 +276,16 @@ def test_gov_notify_bulk_email_action_mixin_action_class(
     )
 
     action.save({'bulk_email_entries': [
-        {'first_name': 'one', 'email': 'one@example.com'},
-        {'first_name': 'two', 'email': 'two@example.com'},
-        {'first_name': 'three', 'email': 'three@example.com'}
+        {'name': 'one', 'email': 'one@example.com'},
+        {'name': 'two', 'email': 'two@example.com'},
+        {'name': 'three', 'email': 'three@example.com'}
     ]})
     assert mock_client.submit_generic.call_count == 1
     assert mock_client.submit_generic.call_args == mock.call({
         'data': {'bulk_email_entries': [
-            {'first_name': 'one', 'email': 'one@example.com'},
-            {'first_name': 'two', 'email': 'two@example.com'},
-            {'first_name': 'three', 'email': 'three@example.com'}
+            {'name': 'one', 'email': 'one@example.com'},
+            {'name': 'two', 'email': 'two@example.com'},
+            {'name': 'three', 'email': 'three@example.com'}
         ]},
         'meta': {
             'action_name': 'gov-notify-bulk-email',
@@ -320,17 +320,17 @@ def test_gov_notify_bulk_email_action_mixin_action_class_no_reply_id(
     )
 
     action.save({'bulk_email_entries': [
-        {'first_name': 'one', 'email': 'one@example.com'},
-        {'first_name': 'two', 'email': 'two@example.com'},
-        {'first_name': 'three', 'email': 'three@example.com'}
+        {'name': 'one', 'email': 'one@example.com'},
+        {'name': 'two', 'email': 'two@example.com'},
+        {'name': 'three', 'email': 'three@example.com'}
     ]})
 
     assert mock_client.submit_generic.call_count == 1
     assert mock_client.submit_generic.call_args == mock.call({
         'data': {'bulk_email_entries': [
-            {'first_name': 'one', 'email': 'one@example.com'},
-            {'first_name': 'two', 'email': 'two@example.com'},
-            {'first_name': 'three', 'email': 'three@example.com'}
+            {'name': 'one', 'email': 'one@example.com'},
+            {'name': 'two', 'email': 'two@example.com'},
+            {'name': 'three', 'email': 'three@example.com'}
         ]},
         'meta': {
             'action_name': 'gov-notify-bulk-email',

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -268,7 +268,6 @@ def test_gov_notify_bulk_email_action_mixin_action_class(
     action = actions.GovNotifyBulkEmailAction(
         client=mock_client,
         template_id='123456',
-        email_addresses=['one@example.com', 'two@example.com', 'three@example.com'],
         email_reply_to_id='123',
         form_url='/the/form/',
         form_session=form_session,
@@ -276,14 +275,21 @@ def test_gov_notify_bulk_email_action_mixin_action_class(
         sender=sender,
     )
 
-    action.save({'name': 'hello'})
+    action.save({'bulk_email_entries': [
+        {'first_name': 'one', 'email': 'one@example.com'},
+        {'first_name': 'two', 'email': 'two@example.com'},
+        {'first_name': 'three', 'email': 'three@example.com'}
+    ]})
     assert mock_client.submit_generic.call_count == 1
     assert mock_client.submit_generic.call_args == mock.call({
-        'data': {'name': 'hello'},
+        'data': {'bulk_email_entries': [
+            {'first_name': 'one', 'email': 'one@example.com'},
+            {'first_name': 'two', 'email': 'two@example.com'},
+            {'first_name': 'three', 'email': 'three@example.com'}
+        ]},
         'meta': {
             'action_name': 'gov-notify-bulk-email',
             'template_id': '123456',
-            'email_addresses': ['one@example.com', 'two@example.com', 'three@example.com'],
             'email_reply_to_id': '123',
             'form_url': '/the/form/',
             'funnel_steps': ['one', 'two'],
@@ -307,22 +313,28 @@ def test_gov_notify_bulk_email_action_mixin_action_class_no_reply_id(
     action = actions.GovNotifyBulkEmailAction(
         client=mock_client,
         template_id='123456',
-        email_addresses=['one@example.com', 'two@example.com', 'three@example.com'],
         form_url='/the/form/',
         form_session=form_session,
         spam_control=spam_control,
         sender=sender,
     )
 
-    action.save({'name': 'hello'})
+    action.save({'bulk_email_entries': [
+        {'first_name': 'one', 'email': 'one@example.com'},
+        {'first_name': 'two', 'email': 'two@example.com'},
+        {'first_name': 'three', 'email': 'three@example.com'}
+    ]})
 
     assert mock_client.submit_generic.call_count == 1
     assert mock_client.submit_generic.call_args == mock.call({
-        'data': {'name': 'hello'},
+        'data': {'bulk_email_entries': [
+            {'first_name': 'one', 'email': 'one@example.com'},
+            {'first_name': 'two', 'email': 'two@example.com'},
+            {'first_name': 'three', 'email': 'three@example.com'}
+        ]},
         'meta': {
             'action_name': 'gov-notify-bulk-email',
             'template_id': '123456',
-            'email_addresses': ['one@example.com', 'two@example.com', 'three@example.com'],
             'form_url': '/the/form/',
             'funnel_steps': ['one', 'two'],
             'ingress_url': 'example.com',

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -320,9 +320,9 @@ def test_gov_notify_bulk_email_action(
 
     data = {
         'bulk_email_entries': [
-            {'first_name': 'one', 'email': 'one@example.com'},
-            {'first_name': 'two', 'email': 'two@example.com'},
-            {'first_name': 'three', 'email': 'three@example.com'}
+            {'name': 'one', 'email': 'one@example.com'},
+            {'name': 'two', 'email': 'two@example.com'},
+            {'name': 'three', 'email': 'three@example.com'}
         ],
         'template_id': '123456',
         'title': 'some title',

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -320,9 +320,9 @@ def test_gov_notify_bulk_email_action(
 
     data = {
         'bulk_email_entries': [
-            {'name': 'one', 'email': 'one@example.com'},
-            {'name': 'two', 'email': 'two@example.com'},
-            {'name': 'three', 'email': 'three@example.com'}
+            {'name': 'one', 'email_address': 'one@example.com'},
+            {'name': 'two', 'email_address': 'two@example.com'},
+            {'name': 'three', 'email_address': 'three@example.com'}
         ],
         'template_id': '123456',
         'title': 'some title',

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -319,7 +319,11 @@ def test_gov_notify_bulk_email_action(
         title = fields.CharField()
 
     data = {
-        'email_addresses': ['one@example.com', 'two@example.com', 'three@example.com'],
+        'bulk_email_entries': [
+            {'first_name': 'one', 'email': 'one@example.com'},
+            {'first_name': 'two', 'email': 'two@example.com'},
+            {'first_name': 'three', 'email': 'three@example.com'}
+        ],
         'template_id': '123456',
         'title': 'some title',
     }
@@ -329,7 +333,7 @@ def test_gov_notify_bulk_email_action(
 
     form.save(
         template_id=data['template_id'],
-        email_addresses=data['email_addresses'],
+        bulk_email_entries=data['bulk_email_entries'],
         email_reply_to_id='123',
         form_url='/the/form/',
         form_session=form_session,
@@ -340,7 +344,7 @@ def test_gov_notify_bulk_email_action(
     assert mock_action_class.call_count == 1
     assert mock_action_class.call_args == mock.call(
         template_id=data['template_id'],
-        email_addresses=data['email_addresses'],
+        bulk_email_entries=data['bulk_email_entries'],
         email_reply_to_id='123',
         form_url='/the/form/',
         form_session=form_session,


### PR DESCRIPTION
An update to the gov-notify-bulk-email action, that allows the submission of freeform template data. 

